### PR TITLE
SOAP Requests Progressive Backoff

### DIFF
--- a/src/CommunicatorSdk.php
+++ b/src/CommunicatorSdk.php
@@ -38,9 +38,9 @@ class CommunicatorSdk {
                 return $client->{$name}((array) $resource);
             } catch (\SoapFault $e) {
 
-                // If we have maxed out our attempts, exit and show the exception
+                // If we have maxed out our attempts, throw the exception
                 if ($attempt == $attempts) {
-                    exit ('Error: ' . $e->__toString());
+                    throw $e;
                 }
 
                 // Backoff 1.5 ^ $attempt seconds

--- a/src/CommunicatorSdk.php
+++ b/src/CommunicatorSdk.php
@@ -26,11 +26,28 @@ class CommunicatorSdk {
 
 		$header_name = $header_reflection->getShortName();
 
-		$client = new SoapClient($service->url . '?WSDL', array("trace" => 1, "exception" => 0, 'soap_version' => \SOAP_1_2));
+		$client = new SoapClient($service->url . '?WSDL', array("trace" => 1, 'soap_version' => \SOAP_1_2));
 
 		$header = new SoapHeader('http://ws.communicatorcorp.com/', $header_name, $service->header);
 		$client->__setSoapHeaders($header);
-		return $client->{$name}((array) $resource);
+
+        // Progressive Backoff attempts to the API before giving up
+        $attempts = 5;
+        for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+            try {
+                return $client->{$name}((array) $resource);
+            } catch (\SoapFault $e) {
+
+                // If we have maxed out our attempts, exit and show the exception
+                if ($attempt == $attempts) {
+                    exit ('Error: ' . $e->__toString());
+                }
+
+                // Backoff 1.5 ^ $attempt seconds
+                $timeout = (1.5 ** $attempt) * 1000000;
+                usleep($timeout);
+            }
+        }
 	}
 
 	protected function service($type)


### PR DESCRIPTION
Fix SOAP Request silent failures and make multiple attempts using progressive backoff.

If after 5 attempts, we are still getting exceptions, rethrow the exception (this should stop the application dead).